### PR TITLE
More README.md improvements.

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -16,9 +16,8 @@ INSTALL
 -------
 
 ```sh
-$ export GOPATH=<path/to/your/go/workspace>
-$ go install -u github.com/grpc-common/go/greeter_client
-$ go install -u github.com/grpc-common/go/greeter_server
+$ go get -u github.com/grpc-common/go/greeter_client
+$ go get -u github.com/grpc-common/go/greeter_server
 ```
 
 TRY IT!


### PR DESCRIPTION
Suggest the standard `go get` for downloading the demo.
Remove instruction to set GOPATH during install flow,
since the prerequisites section already does that.
