### PR TITLE
Remove 404 link for python example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Hello World example. You'll find more tutorials and reference docs in this repos
 You can find quick start guides for each language, including installation instructions, examples, and tutorials here:
 * [C++](https://github.com/grpc/grpc-common/tree/master/cpp)
 * [Java](https://github.com/grpc/grpc-common/tree/master/java)
-* [Python](https://github.com/grpc/grpc-common/tree/master/python)
 * [Go](https://github.com/grpc/grpc-common/tree/master/go)
 * [ruby](https://github.com/grpc/grpc-common/tree/master/ruby)
 * [Node.js](https://github.com/grpc/grpc-common/tree/master/node)
+* Python is coming soon
 
 ## What's in this repository?
 


### PR DESCRIPTION
There is no Python Hello World sample yet, so the link was a 404. Replaced it with a "Python coming soon" bullet (no link).
