### PR TITLE
Remove reference to Netty 5

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -7,7 +7,7 @@ PREREQUISITES
 - [Java 8](http://docs.oracle.com/javase/8/docs/technotes/guides/install/install_overview.html)
 
 - [Maven 3.2 or later](http://maven.apache.org/download.cgi).
-  - this is needed to install Netty5, a dependency of gRPC
+  - this is needed to install Netty, a dependency of gRPC
 
 INSTALL
 -------


### PR DESCRIPTION
grpc-java now depends on Netty 4.1. Simply removing the version doesn't seem to reduce the doc's usefulness but also prevents needing to update it as much.