### PR TITLE
Update grpc-common and grpc-java url

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ following command:
 
 
 ```
-git clone https://github.com/google/grpc-java.git
+git clone https://github.com/grpc/grpc-java.git
 ```
 
 Change your current directory to grpc-java/examples

--- a/cpp/helloworld/README.md
+++ b/cpp/helloworld/README.md
@@ -12,7 +12,7 @@ following command:
 
 
 ```sh
-$ git clone https://github.com/google/grpc-common.git
+$ git clone https://github.com/grpc/grpc-common.git
 ```
 
 Change your current directory to grpc-common/cpp/helloworld

--- a/java/javatutorial.md
+++ b/java/javatutorial.md
@@ -20,7 +20,7 @@ With gRPC we can define our service once in a .proto file and implement clients 
 
 The example code for our tutorial is in [grpc/grpc-java/examples/src/main/java/io/grpc/examples](https://github.com/grpc/grpc-java/tree/master/examples/src/main/java/io/grpc/examples). To download the example, clone the `grpc-java` repository by running the following command:
 ```shell
-$ git clone https://github.com/google/grpc-java.git
+$ git clone https://github.com/grpc/grpc-java.git
 ```
 
 Then change your current directory to `grpc-java/examples`:

--- a/node/route_guide/README.md
+++ b/node/route_guide/README.md
@@ -19,7 +19,7 @@ With gRPC we can define our service once in a .proto file and implement clients 
 
 The example code for our tutorial is in [grpc/grpc-common/node/route_guide](https://github.com/grpc/grpc-common/tree/master/node/route_guide). To download the example, clone the `grpc-common` repository by running the following command:
 ```shell
-$ git clone https://github.com/google/grpc-common.git
+$ git clone https://github.com/grpc/grpc-common.git
 ```
 
 Then change your current directory to `grpc-common/node/route_guide`:

--- a/ruby/route_guide/README.md
+++ b/ruby/route_guide/README.md
@@ -20,7 +20,7 @@ With gRPC we can define our service once in a .proto file and implement clients 
 
 The example code for our tutorial is in [grpc/grpc-common/ruby/route_guide](https://github.com/grpc/grpc-common/tree/master/ruby/route_guide). To download the example, clone the `grpc-common` repository by running the following command:
 ```shell
-$ git clone https://github.com/google/grpc-common.git
+$ git clone https://github.com/grpc/grpc-common.git
 ```
 
 Then change your current directory to `grpc-common/ruby/route_guide`:


### PR DESCRIPTION
grpc-common and grpc-java url was pointing to google/grpc-*.
Actually grpc-java is not a problem because it seems currently redirecting to grpc/grpc-java though.
google/grpc-common.git didn't work for me.