### PR TITLE
fix ambiguous namespace error on route_guide_client.cc from MSVC

### DIFF
--- a/cpp/route_guide/route_guide_client.cc
+++ b/cpp/route_guide/route_guide_client.cc
@@ -104,7 +104,7 @@ class RouteGuideClient {
   }
 
   void ListFeatures() {
-    Rectangle rect;
+    examples::Rectangle rect;
     Feature feature;
     ClientContext context;
 


### PR DESCRIPTION
cc9d6032001a6192b208dbd38940893f00360c0f
ditto

Sorry, I just forgot to add to PR client-side file (route_guide_client.cc)
