### PR TITLE
We can now use the gRPC gem directly from git.

### DIFF
--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -3,4 +3,4 @@
 
 source 'https://rubygems.org/'
 
-gemspec
+gem 'grpc', :git => 'https://github.com/grpc/grpc.git', :submodules => true, glob: 'src/ruby/*.gemspec'

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -32,11 +32,6 @@ INSTALL
 -------
 
 - Clone this repository
-- Install gRPC Ruby using the brew-based installer
-```sh
-$ curl -fsSL https://raw.githubusercontent.com/tbetbetbe/homebrew-grpc/master/scripts/install | bash -s ruby
-```
-
 - Use bundler to install the example package's dependencies
 ```sh
 $ # from this directory


### PR DESCRIPTION
With the release of bundler 1.10, we can now simplify the build steps, and use the git repository directly as a ruby gem, without having to install gRPC at all, hence having virtually no other installation step than `bundler install`.

While the simplification of the installation steps is definitely desired, this change of that specific example may or may not be desirable, depending on how we wish to push towards using brew or not. I could also see us doing it in a separate example to showcase how to do it, if that's a better thing for us to do.