### PR TITLE
Update README.md

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -3,61 +3,59 @@ gRPC in 3 minutes (Ruby)
 
 BACKGROUND
 -------------
-For this sample, we've already generated the server and client stubs from [helloworld.proto](https://github.com/grpc/grpc-common/blob/master/protos/helloworld.proto). 
+For this sample, we've already generated the server and client stubs from [helloworld.proto][]
 
 PREREQUISITES
 -------------
 
 - Ruby 2.x
-
 This requires Ruby 2.x, as the gRPC API surface uses keyword args.
-If you don't have that installed locally, you can use [RVM](https://www.rvm.io/) to use Ruby 2.x for testing without upgrading the version of Ruby on your whole system.
+If you don't have that installed locally, you can use [RVM][] to use Ruby 2.x for testing without upgrading the version of Ruby on your whole system.
 RVM is also useful if you don't have the necessary privileges to update your system's Ruby.
-```sh
-$ # RVM installation as specified at https://rvm.io/rvm/install
-$ gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
-$ \curl -sSL https://get.rvm.io | bash -s stable --ruby=ruby-2
-$
-$ # follow the instructions to ensure that your're using the latest stable version of Ruby
-$ # and that the rvm command is installed
-```
+
+  ```sh
+  $ # RVM installation as specified at https://rvm.io/rvm/install
+  $ gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+  $ \curl -sSL https://get.rvm.io | bash -s stable --ruby=ruby-2
+  $
+  $ # follow the instructions to ensure that your're using the latest stable version of Ruby
+  $ # and that the rvm command is installed
+  ```
 - *N.B* Make sure your run `source $HOME/.rvm/scripts/rvm` as instructed to complete the set-up of RVM.
-
-- Homebrew/Linuxbrew
-
-The gRPC core will be installed using [Linuxbrew][Linuxbrew] for Linux and [Homebrew][Homebrew] on Macs.
-Please ensure these are installed before proceeding.
 
 INSTALL
 -------
 
 - Clone this repository
 - Use bundler to install the example package's dependencies
-```sh
-$ # from this directory
-$ gem install bundler # if you don't already have bundler available
-$ bundle install
-```
+
+  ```sh
+  $ # from this directory
+  $ gem install bundler # if you don't already have bundler available
+  $ bundle install
+  ```
 
 Try it! 
 -------
 
 - Run the server
-```sh
-$ # from this directory
-$ bundle exec ./greeter_server.rb &
-```
+
+  ```sh
+  $ # from this directory
+  $ bundle exec ./greeter_server.rb &
+  ```
 
 - Run the client
-```sh
-$ # from this directory
-$ bundle exec ./greeter_client.rb
-```
+
+  ```sh
+  $ # from this directory
+  $ bundle exec ./greeter_client.rb
+  ```
 
 Tutorial
 --------
 
 You can find a more detailed tutorial in [gRPC Basics: Ruby](https://github.com/grpc/grpc-common/blob/master/ruby/route_guide/README.md)
 
-[Homebrew]: https://github.com/Homebrew/homebrew
-[Linuxbrew]: https://github.com/Homebrew/linuxbrew
+[helloworld.proto]:https://github.com/grpc/grpc-common/blob/master/protos/helloworld.proto
+[RVM]:https://www.rvm.io/


### PR DESCRIPTION
- this is slightly different;  it does use homebrew but instead uses a unique new feature of bundler, which allows building the grpc extension directly from the git repo instead of installing grpc gem.

- this new feature is only available in bundler, the ruby deployment tool; we use it here as it simplifies the helloworld instructions.
- it's not available in other grpc languages, and outside of this example it's better to recommend that users use the homebrew install