### PR TITLE
ruby route_guide server logger is undefined

### DIFF
--- a/ruby/route_guide/route_guide_server.rb
+++ b/ruby/route_guide/route_guide_server.rb
@@ -203,7 +203,7 @@ def main
   port = '0.0.0.0:50051'
   s = GRPC::RpcServer.new
   s.add_http2_port(port)
-  logger.info("... running insecurely on #{port}")
+  GRPC.logger.info("... running insecurely on #{port}")
   s.handle(ServerImpl.new(feature_db))
   s.run
 end


### PR DESCRIPTION
error when running ruby route_guide_server.rb

```
stanleycheung@stanleycheung-test:~/grpc-common/ruby$ bundle exec route_guide/route_guide_server.rb ../node/route_guide/route_guide_db.json
I0611 23:54:04.794703782   18226 socket_utils_common_posix.c:148] Disabling AF_INET6 sockets because ::1 is not available.
route_guide/route_guide_server.rb:206:in `main': undefined local variable or method `logger' for main:Object (NameError)
	from route_guide/route_guide_server.rb:211:in `<main>'
D0611 23:54:04.798307688   18226 iomgr.c:120] Waiting for 1 iomgr objects to be destroyed
D0611 23:54:14.798317357   18226 iomgr.c:145] Failed to free 1 iomgr objects before shutdown deadline: memory leaks are likely
D0611 23:54:14.798349921   18226 iomgr.c:150] LEAKED OBJECT: tcp-server-listener:(sockaddr family=65408)
stanleycheung@stanleycheung-test:~/grpc-common/ruby$ 
```