### PR TITLE
Add "useful resources" section and a link to another demo project

### DIFF
--- a/java/android/README.md
+++ b/java/android/README.md
@@ -39,3 +39,7 @@ $ git clone https://github.com/grpc/grpc-common
 $ cd grpc-common/java/android
 $ ./gradlew installDebug
 ```
+
+Useful resources
+----------------
+- Another [example project](https://github.com/Lovoo/grpc-android-demo) for GRPC on Android featuring code generation from a proto file via gradle and a simple Java server implementation


### PR DESCRIPTION
As I struggled with automatic code generation and didn't find any answers in this project where the necessary stubs are already included I created another demo project which incorporates an example for code generation may work using the protobuf-gradle-plugin (https://github.com/google/protobuf-gradle-plugin). The project also includes a simple server implementation which also uses the generated stubs. There is no additional setup (i.e. installing gRPC Java or protoc) necessary. The provided link should point those to this project who are interested in getting gRPC on Android up and running as fast as possible.