### PR TITLE
Remove port-forwarding in start_docker.sh

### DIFF
--- a/gdebug/docker/start_docker.sh
+++ b/gdebug/docker/start_docker.sh
@@ -23,9 +23,6 @@ services:
     build:
       context: ./envoy/
       dockerfile: Dockerfile
-    ports:
-      # Forward host port to docker
-      - '$ENVOY_PORT:$ENVOY_PORT'
     environment:
       - GRPC_HOST=$GRPC_ADDR
       - GRPC_PORT=$GRPC_PORT


### PR DESCRIPTION
This PR fixes an issue in config causing Docker to fail.

In short, port forwarding is not compatible with host network. See more here: https://docs.docker.com/network/host/

In addition, it may be a good idea to add a piece of documentation saying this shell script is not suitable for Docker Desktop, since the host networking is only available for Docker on Linux.